### PR TITLE
Add browser-style scraping for price fetcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(FoodcoopPriceTracker VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Widgets Network Sql Charts)
+
+add_executable(price_tracker
+    src/main.cpp
+    src/PriceFetcher.cpp
+    src/DatabaseManager.cpp
+    src/TrendDetector.cpp
+    src/PlotWindow.cpp
+)
+
+target_link_libraries(price_tracker PRIVATE
+    Qt6::Widgets
+    Qt6::Network
+    Qt6::Sql
+    Qt6::Charts
+)
+
+install(TARGETS price_tracker DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-# Foodcoop
+# Foodcoop Price Tracker
 
-WIP
+This example Qt6 application fetches daily prices from Swiss grocery stores,
+stores them in a SQLite database and plots the price history. A simple trend
+detection is performed using linear regression on the stored prices.
+
+The `PriceFetcher` class now mimics a desktop browser when requesting product
+pages from Coop, Migros, Denner, Aldi Suisse and Lidl Suisse. Because the
+stores do not provide open APIs, the price is extracted from the HTML using a
+simple regular expression. The included URLs and regex patterns are examples and
+may require adjustment as the page markup changes.
+
+## Building
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```
+
+Run the application with `./price_tracker`.

--- a/src/DatabaseManager.cpp
+++ b/src/DatabaseManager.cpp
@@ -1,0 +1,55 @@
+#include "DatabaseManager.h"
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QSqlRecord>
+#include <QDebug>
+
+DatabaseManager::DatabaseManager(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool DatabaseManager::open(const QString &path)
+{
+    m_db = QSqlDatabase::addDatabase("QSQLITE");
+    m_db.setDatabaseName(path);
+    if (!m_db.open()) {
+        qWarning() << "Failed to open database" << m_db.lastError();
+        return false;
+    }
+    QSqlQuery query;
+    query.exec("CREATE TABLE IF NOT EXISTS prices (store TEXT, item TEXT, date TEXT, price REAL)");
+    return true;
+}
+
+void DatabaseManager::insertPrice(const PriceEntry &entry)
+{
+    QSqlQuery query;
+    query.prepare("INSERT INTO prices (store, item, date, price) VALUES (?, ?, ?, ?)");
+    query.addBindValue(entry.store);
+    query.addBindValue(entry.item);
+    query.addBindValue(entry.date.toString(Qt::ISODate));
+    query.addBindValue(entry.price);
+    if (!query.exec()) {
+        qWarning() << "Insert failed" << query.lastError();
+    }
+}
+
+QList<PriceEntry> DatabaseManager::loadPrices(const QString &item) const
+{
+    QList<PriceEntry> list;
+    QSqlQuery query;
+    query.prepare("SELECT store, item, date, price FROM prices WHERE item = ? ORDER BY date");
+    query.addBindValue(item);
+    if (query.exec()) {
+        while (query.next()) {
+            PriceEntry entry;
+            entry.store = query.value(0).toString();
+            entry.item = query.value(1).toString();
+            entry.date = QDate::fromString(query.value(2).toString(), Qt::ISODate);
+            entry.price = query.value(3).toDouble();
+            list.append(entry);
+        }
+    }
+    return list;
+}

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <QObject>
+#include <QSqlDatabase>
+#include "PriceFetcher.h"
+
+class DatabaseManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DatabaseManager(QObject *parent = nullptr);
+    bool open(const QString &path);
+    void insertPrice(const PriceEntry &entry);
+    QList<PriceEntry> loadPrices(const QString &item) const;
+
+private:
+    QSqlDatabase m_db;
+};

--- a/src/PlotWindow.cpp
+++ b/src/PlotWindow.cpp
@@ -1,0 +1,37 @@
+#include "PlotWindow.h"
+#include <QtCharts/QChart>
+#include <QtCharts/QChartView>
+#include <QtCharts/QLineSeries>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QDebug>
+
+using namespace QtCharts;
+
+PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
+    : QMainWindow(parent), m_db(db)
+{
+    m_series = new QLineSeries(this);
+    m_chartView = new QChartView(new QChart(), this);
+    m_chartView->chart()->addSeries(m_series);
+    m_chartView->chart()->createDefaultAxes();
+    setCentralWidget(m_chartView);
+
+    m_timer = new QTimer(this);
+    connect(m_timer, &QTimer::timeout, this, &PlotWindow::updateChart);
+    m_timer->start(10000); // refresh every 10 seconds
+
+    updateChart();
+}
+
+void PlotWindow::updateChart()
+{
+    QList<PriceEntry> prices = m_db->loadPrices("sample");
+    m_series->clear();
+    for (const PriceEntry &p : prices) {
+        m_series->append(p.date.toJulianDay(), p.price);
+    }
+    m_chartView->chart()->createDefaultAxes();
+    QString trend = m_detector.detectTrend(prices);
+    m_chartView->chart()->setTitle("Price trend: " + trend);
+}

--- a/src/PlotWindow.h
+++ b/src/PlotWindow.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <QMainWindow>
+#include <QChartView>
+#include <QLineSeries>
+#include "DatabaseManager.h"
+#include "TrendDetector.h"
+
+QT_BEGIN_NAMESPACE
+class QTimer;
+QT_END_NAMESPACE
+
+class PlotWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    PlotWindow(DatabaseManager *db, QWidget *parent = nullptr);
+
+private slots:
+    void updateChart();
+
+private:
+    DatabaseManager *m_db;
+    TrendDetector m_detector;
+    QtCharts::QChartView *m_chartView;
+    QtCharts::QLineSeries *m_series;
+    QTimer *m_timer;
+};

--- a/src/PriceFetcher.cpp
+++ b/src/PriceFetcher.cpp
@@ -1,0 +1,71 @@
+#include "PriceFetcher.h"
+#include <QRegularExpression>
+#include <QDate>
+#include <QUrl>
+
+PriceFetcher::PriceFetcher(QObject *parent)
+    : QObject(parent)
+{
+    connect(&m_manager, &QNetworkAccessManager::finished,
+            this, &PriceFetcher::onReply);
+
+    // Example product pages. These URLs are publicly accessible HTML pages and
+    // not official API endpoints. We request them with a desktop User-Agent and
+    // extract the price using a regular expression. The regex patterns are
+    // simple and may need adjustment if the page structure changes.
+    m_products = {
+        {"Coop", "Milk",
+         "https://www.coop.ch/en/shop/getraenke/milch/coop-milch-35-/p/614300600000",
+         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
+        {"Migros", "Milk",
+         "https://produkte.migros.ch/migros-milch-vollmilch",
+         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
+        {"Denner", "Milk",
+         "https://www.denner.ch/de/shop/getraenke/milch/p/30700/",
+         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
+        {"Aldi Suisse", "Milk",
+         "https://www.aldi-suisse.ch/de/sortiment/kuhlprodukte/milch/p/10203/",
+         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
+        {"Lidl Suisse", "Milk",
+         "https://www.lidl.ch/de/Milch/p1000",
+         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")}
+    };
+}
+
+void PriceFetcher::fetchDailyPrices()
+{
+    m_pending = m_products.size();
+    for (const StoreProduct &p : m_products) {
+        QNetworkRequest request(QUrl(p.url));
+        request.setHeader(QNetworkRequest::UserAgentHeader,
+                          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                          "(KHTML, like Gecko) Chrome/120.0 Safari/537.36");
+        QNetworkReply *reply = m_manager.get(request);
+        reply->setProperty("store", p.store);
+        reply->setProperty("item", p.item);
+        reply->setProperty("regex", p.priceRegex.pattern());
+    }
+}
+
+void PriceFetcher::onReply(QNetworkReply *reply)
+{
+    PriceEntry entry;
+    entry.store = reply->property("store").toString();
+    entry.item = reply->property("item").toString();
+    entry.date = QDate::currentDate();
+    entry.price = 0.0;
+
+    const QByteArray data = reply->readAll();
+    QString pattern = reply->property("regex").toString();
+    QRegularExpression regex(pattern);
+    QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
+    if (match.hasMatch())
+        entry.price = match.captured(1).toDouble();
+
+    emit priceFetched(entry);
+
+    if (--m_pending == 0)
+        emit fetchFinished();
+
+    reply->deleteLater();
+}

--- a/src/PriceFetcher.h
+++ b/src/PriceFetcher.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QList>
+#include <QUrl>
+#include <QRegularExpression>
+
+struct PriceEntry {
+    QString store;
+    QString item;
+    QDate date;
+    double price;
+};
+
+class PriceFetcher : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PriceFetcher(QObject *parent = nullptr);
+    void fetchDailyPrices();
+
+signals:
+    void priceFetched(const PriceEntry &entry);
+    void fetchFinished();
+
+private slots:
+    void onReply(QNetworkReply *reply);
+
+private:
+    struct StoreProduct {
+        QString store;
+        QString item;
+        QString url;
+        QRegularExpression priceRegex;
+    };
+    QList<StoreProduct> m_products;
+    int m_pending = 0;
+    QNetworkAccessManager m_manager;
+};

--- a/src/TrendDetector.cpp
+++ b/src/TrendDetector.cpp
@@ -1,0 +1,30 @@
+#include "TrendDetector.h"
+#include <QtMath>
+
+TrendDetector::TrendDetector(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QString TrendDetector::detectTrend(const QList<PriceEntry> &prices) const
+{
+    if (prices.size() < 2)
+        return "stable";
+
+    double sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
+    int n = prices.size();
+    for (int i = 0; i < n; ++i) {
+        double x = i;
+        double y = prices[i].price;
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumXX += x * x;
+    }
+    double slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX + 1e-9);
+    if (slope > 0.01)
+        return "upward";
+    if (slope < -0.01)
+        return "downward";
+    return "stable";
+}

--- a/src/TrendDetector.h
+++ b/src/TrendDetector.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <QObject>
+#include "PriceFetcher.h"
+
+class TrendDetector : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TrendDetector(QObject *parent = nullptr);
+    QString detectTrend(const QList<PriceEntry> &prices) const;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,22 @@
+#include <QApplication>
+#include "PriceFetcher.h"
+#include "DatabaseManager.h"
+#include "PlotWindow.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    DatabaseManager db;
+    db.open("prices.db");
+
+    PlotWindow w(&db);
+    w.show();
+
+    PriceFetcher fetcher;
+    QObject::connect(&fetcher, &PriceFetcher::priceFetched,
+                     [&db](const PriceEntry &entry){ db.insertPrice(entry); });
+    fetcher.fetchDailyPrices();
+
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- update README to mention scraping from HTML pages
- fetch real product pages with browser user-agent
- parse prices using regular expressions

## Testing
- `cmake --version`
- `cmake ..` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6840c8c269c08330984cd4c0719826ac