### PR TITLE
Add product filtering and date selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake g++ build-essential \
+          qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools \
+          qt6-charts-dev libqt6sql6-sqlite
+    - name: Configure CMake
+      run: cmake -B build
+    - name: Build
+      run: cmake --build build -j $(nproc)
+    - name: Install
+      run: cmake --install build --prefix dist
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: price_tracker
+        path: dist/

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -9,9 +9,14 @@ class DatabaseManager : public QObject
 public:
     explicit DatabaseManager(QObject *parent = nullptr);
     bool open(const QString &path);
+    QString databasePath() const;
     void insertPrice(const PriceEntry &entry);
-    QList<PriceEntry> loadPrices(const QString &item) const;
+    QList<PriceEntry> loadPrices(const QString &item,
+                                 const QString &store = QString(),
+                                 const QDate &fromDate = QDate()) const;
+    PriceEntry latestPrice(const QString &item, const QString &store) const;
 
 private:
     QSqlDatabase m_db;
+    QString m_dbPath;
 };

--- a/src/PlotWindow.cpp
+++ b/src/PlotWindow.cpp
@@ -5,8 +5,14 @@
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QDebug>
+#include <QDockWidget>
+#include <QComboBox>
+#include <QLabel>
+#include <QFileInfo>
+#include <QDateEdit>
+#include <QTabWidget>
+#include <QTableWidget>
 
-using namespace QtCharts;
 
 PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     : QMainWindow(parent), m_db(db)
@@ -15,7 +21,55 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     m_chartView = new QChartView(new QChart(), this);
     m_chartView->chart()->addSeries(m_series);
     m_chartView->chart()->createDefaultAxes();
-    setCentralWidget(m_chartView);
+
+    m_table = new QTableWidget(this);
+    m_table->setColumnCount(2);
+    m_table->setHorizontalHeaderLabels({tr("Date"), tr("Price")});
+
+    m_tabs = new QTabWidget(this);
+    m_tabs->addTab(m_chartView, tr("Chart"));
+    m_tabs->addTab(m_table, tr("Table"));
+    setCentralWidget(m_tabs);
+
+    // Create user menu dock
+    m_menuDock = new QDockWidget(tr("Menu"), this);
+    QWidget *dockWidget = new QWidget(m_menuDock);
+    QVBoxLayout *dockLayout = new QVBoxLayout(dockWidget);
+
+    m_dbSizeLabel = new QLabel(dockWidget);
+    dockLayout->addWidget(m_dbSizeLabel);
+
+    m_browserStatusLabel = new QLabel(tr("Browser: Idle"), dockWidget);
+    dockLayout->addWidget(m_browserStatusLabel);
+
+    dockLayout->addWidget(new QLabel(tr("Market:"), dockWidget));
+    m_storeCombo = new QComboBox(dockWidget);
+    m_storeCombo->addItems({"Coop", "Migros", "Denner", "Aldi Suisse", "Lidl Suisse"});
+    dockLayout->addWidget(m_storeCombo);
+    connect(m_storeCombo, &QComboBox::currentTextChanged, this, &PlotWindow::onStoreChanged);
+
+    dockLayout->addWidget(new QLabel(tr("Category:"), dockWidget));
+    m_categoryCombo = new QComboBox(dockWidget);
+    m_categoryCombo->addItems({"Milk"});
+    dockLayout->addWidget(m_categoryCombo);
+    connect(m_categoryCombo, &QComboBox::currentTextChanged, this, &PlotWindow::onCategoryChanged);
+
+    dockLayout->addWidget(new QLabel(tr("From:"), dockWidget));
+    m_fromDateEdit = new QDateEdit(QDate::currentDate().addDays(-30), dockWidget);
+    m_fromDateEdit->setCalendarPopup(true);
+    dockLayout->addWidget(m_fromDateEdit);
+    connect(m_fromDateEdit, &QDateEdit::dateChanged, this, &PlotWindow::onFromDateChanged);
+
+    m_currentPriceLabel = new QLabel(dockWidget);
+    dockLayout->addWidget(m_currentPriceLabel);
+
+    dockWidget->setLayout(dockLayout);
+    m_menuDock->setWidget(dockWidget);
+    addDockWidget(Qt::LeftDockWidgetArea, m_menuDock);
+
+    m_currentStore = m_storeCombo->currentText();
+    m_currentCategory = m_categoryCombo->currentText();
+    updateDbInfo();
 
     m_timer = new QTimer(this);
     connect(m_timer, &QTimer::timeout, this, &PlotWindow::updateChart);
@@ -26,12 +80,84 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
 
 void PlotWindow::updateChart()
 {
-    QList<PriceEntry> prices = m_db->loadPrices("sample");
+    QList<PriceEntry> prices = m_db->loadPrices(m_currentCategory, m_currentStore,
+                                               m_fromDateEdit->date());
     m_series->clear();
     for (const PriceEntry &p : prices) {
         m_series->append(p.date.toJulianDay(), p.price);
     }
     m_chartView->chart()->createDefaultAxes();
     QString trend = m_detector.detectTrend(prices);
-    m_chartView->chart()->setTitle("Price trend: " + trend);
+    m_chartView->chart()->setTitle(tr("Price trend: %1").arg(trend));
+
+    m_table->setRowCount(prices.size());
+    for (int i = 0; i < prices.size(); ++i) {
+        m_table->setItem(i, 0, new QTableWidgetItem(prices[i].date.toString(Qt::ISODate)));
+        m_table->setItem(i, 1, new QTableWidgetItem(QString::number(prices[i].price)));
+    }
+
+    PriceEntry latest = m_db->latestPrice(m_currentCategory, m_currentStore);
+    if (latest.date.isValid())
+        m_currentPriceLabel->setText(tr("Current price: %1 (%2)")
+                                        .arg(latest.price)
+                                        .arg(latest.date.toString(Qt::ISODate)));
+    else
+        m_currentPriceLabel->setText(tr("Current price: N/A"));
+}
+
+void PlotWindow::onStoreChanged(const QString &store)
+{
+    m_currentStore = store;
+    updateChart();
+}
+
+void PlotWindow::onCategoryChanged(const QString &category)
+{
+    m_currentCategory = category;
+    updateChart();
+}
+
+void PlotWindow::onFetchStarted()
+{
+    m_browserStatusLabel->setText(tr("Browser: Fetching"));
+}
+
+void PlotWindow::onFetchFinished()
+{
+    m_browserStatusLabel->setText(tr("Browser: Idle"));
+    updateDbInfo();
+}
+
+void PlotWindow::onFromDateChanged(const QDate &)
+{
+    updateChart();
+}
+
+void PlotWindow::updateDbInfo()
+{
+    QFileInfo info(m_db->databasePath());
+    m_dbSizeLabel->setText(tr("Database size: %1 KB").arg(info.size() / 1024));
+    PriceEntry latest = m_db->latestPrice(m_currentCategory, m_currentStore);
+    if (latest.date.isValid())
+        m_currentPriceLabel->setText(tr("Current price: %1 (%2)")
+                                        .arg(latest.price)
+                                        .arg(latest.date.toString(Qt::ISODate)));
+    else
+        m_currentPriceLabel->setText(tr("Current price: N/A"));
+}
+
+void PlotWindow::setStoreList(const QStringList &stores)
+{
+    m_storeCombo->clear();
+    m_storeCombo->addItems(stores);
+    m_currentStore = m_storeCombo->currentText();
+    updateChart();
+}
+
+void PlotWindow::setCategoryList(const QStringList &categories)
+{
+    m_categoryCombo->clear();
+    m_categoryCombo->addItems(categories);
+    m_currentCategory = m_categoryCombo->currentText();
+    updateChart();
 }

--- a/src/PlotWindow.h
+++ b/src/PlotWindow.h
@@ -1,9 +1,15 @@
 #pragma once
 #include <QMainWindow>
-#include <QChartView>
-#include <QLineSeries>
+#include <QtCharts/QChartView>
+#include <QtCharts/QLineSeries>
 #include "DatabaseManager.h"
 #include "TrendDetector.h"
+#include <QDockWidget>
+#include <QComboBox>
+#include <QLabel>
+#include <QDateEdit>
+#include <QTabWidget>
+#include <QTableWidget>
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -14,14 +20,33 @@ class PlotWindow : public QMainWindow
     Q_OBJECT
 public:
     PlotWindow(DatabaseManager *db, QWidget *parent = nullptr);
+    void setStoreList(const QStringList &stores);
+    void setCategoryList(const QStringList &categories);
 
-private slots:
+public slots:
     void updateChart();
+    void onStoreChanged(const QString &store);
+    void onCategoryChanged(const QString &category);
+    void onFetchStarted();
+    void onFetchFinished();
+    void onFromDateChanged(const QDate &date);
 
 private:
     DatabaseManager *m_db;
     TrendDetector m_detector;
-    QtCharts::QChartView *m_chartView;
-    QtCharts::QLineSeries *m_series;
+    QChartView *m_chartView;
+    QLineSeries *m_series;
+    QTableWidget *m_table;
+    QTabWidget *m_tabs;
     QTimer *m_timer;
+    QDockWidget *m_menuDock;
+    QLabel *m_dbSizeLabel;
+    QLabel *m_currentPriceLabel;
+    QLabel *m_browserStatusLabel;
+    QComboBox *m_storeCombo;
+    QComboBox *m_categoryCombo;
+    QDateEdit *m_fromDateEdit;
+    QString m_currentStore;
+    QString m_currentCategory;
+    void updateDbInfo();
 };

--- a/src/PriceFetcher.cpp
+++ b/src/PriceFetcher.cpp
@@ -35,6 +35,7 @@ PriceFetcher::PriceFetcher(QObject *parent)
 void PriceFetcher::fetchDailyPrices()
 {
     m_pending = m_products.size();
+    emit fetchStarted();
     for (const StoreProduct &p : m_products) {
         QNetworkRequest request(QUrl(p.url));
         request.setHeader(QNetworkRequest::UserAgentHeader,
@@ -45,6 +46,26 @@ void PriceFetcher::fetchDailyPrices()
         reply->setProperty("item", p.item);
         reply->setProperty("regex", p.priceRegex.pattern());
     }
+}
+
+QStringList PriceFetcher::storeList() const
+{
+    QStringList list;
+    for (const StoreProduct &p : m_products) {
+        if (!list.contains(p.store))
+            list.append(p.store);
+    }
+    return list;
+}
+
+QStringList PriceFetcher::categoryList() const
+{
+    QStringList list;
+    for (const StoreProduct &p : m_products) {
+        if (!list.contains(p.item))
+            list.append(p.item);
+    }
+    return list;
 }
 
 void PriceFetcher::onReply(QNetworkReply *reply)

--- a/src/PriceFetcher.h
+++ b/src/PriceFetcher.h
@@ -19,10 +19,13 @@ class PriceFetcher : public QObject
 public:
     explicit PriceFetcher(QObject *parent = nullptr);
     void fetchDailyPrices();
+    QStringList storeList() const;
+    QStringList categoryList() const;
 
 signals:
     void priceFetched(const PriceEntry &entry);
     void fetchFinished();
+    void fetchStarted();
 
 private slots:
     void onReply(QNetworkReply *reply);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,14 @@ int main(int argc, char *argv[])
     w.show();
 
     PriceFetcher fetcher;
+    w.setStoreList(fetcher.storeList());
+    w.setCategoryList(fetcher.categoryList());
     QObject::connect(&fetcher, &PriceFetcher::priceFetched,
                      [&db](const PriceEntry &entry){ db.insertPrice(entry); });
+    QObject::connect(&fetcher, &PriceFetcher::fetchStarted,
+                     &w, &PlotWindow::onFetchStarted);
+    QObject::connect(&fetcher, &PriceFetcher::fetchFinished,
+                     &w, &PlotWindow::onFetchFinished);
     fetcher.fetchDailyPrices();
 
     return app.exec();


### PR DESCRIPTION
## Summary
- extend `DatabaseManager` with latest price and date filtering support
- show store and category lists and allow date-based filtering in `PlotWindow`
- display current price and build a table view for collected data
- update `main.cpp` to populate UI with available stores and categories

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `cmake --install . --prefix ../dist`


------
https://chatgpt.com/codex/tasks/task_e_6841073d93b0833086cd763ce0b866a2