### PR TITLE
Implement issue tracking and first run scraping

### DIFF
--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -11,10 +11,13 @@ public:
     bool open(const QString &path);
     QString databasePath() const;
     void insertPrice(const PriceEntry &entry);
+    void insertIssue(const IssueEntry &issue);
+    QList<IssueEntry> loadIssues() const;
     QList<PriceEntry> loadPrices(const QString &item,
                                  const QString &store = QString(),
                                  const QDate &fromDate = QDate()) const;
     PriceEntry latestPrice(const QString &item, const QString &store) const;
+    bool hasPrices() const;
 
 private:
     QSqlDatabase m_db;

--- a/src/PlotWindow.h
+++ b/src/PlotWindow.h
@@ -29,7 +29,9 @@ public slots:
     void onCategoryChanged(const QString &category);
     void onFetchStarted();
     void onFetchFinished();
+    void onIssueOccurred(const IssueEntry &issue);
     void onFromDateChanged(const QDate &date);
+    void updateIssues();
 
 private:
     DatabaseManager *m_db;
@@ -37,6 +39,7 @@ private:
     QChartView *m_chartView;
     QLineSeries *m_series;
     QTableWidget *m_table;
+    QTableWidget *m_issueTable;
     QTabWidget *m_tabs;
     QTimer *m_timer;
     QDockWidget *m_menuDock;

--- a/src/PriceFetcher.h
+++ b/src/PriceFetcher.h
@@ -5,12 +5,20 @@
 #include <QList>
 #include <QUrl>
 #include <QRegularExpression>
+#include <QDate>
 
 struct PriceEntry {
     QString store;
     QString item;
     QDate date;
     double price;
+};
+
+struct IssueEntry {
+    QString store;
+    QString item;
+    QDate date;
+    QString error;
 };
 
 class PriceFetcher : public QObject
@@ -24,6 +32,7 @@ public:
 
 signals:
     void priceFetched(const PriceEntry &entry);
+    void issueOccurred(const IssueEntry &issue);
     void fetchFinished();
     void fetchStarted();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,11 +18,17 @@ int main(int argc, char *argv[])
     w.setCategoryList(fetcher.categoryList());
     QObject::connect(&fetcher, &PriceFetcher::priceFetched,
                      [&db](const PriceEntry &entry){ db.insertPrice(entry); });
+    QObject::connect(&fetcher, &PriceFetcher::issueOccurred,
+                     [&db, &w](const IssueEntry &issue){
+                         db.insertIssue(issue);
+                         w.onIssueOccurred(issue);
+                     });
     QObject::connect(&fetcher, &PriceFetcher::fetchStarted,
                      &w, &PlotWindow::onFetchStarted);
     QObject::connect(&fetcher, &PriceFetcher::fetchFinished,
                      &w, &PlotWindow::onFetchFinished);
-    fetcher.fetchDailyPrices();
+    if (!db.hasPrices())
+        fetcher.fetchDailyPrices();
 
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- fetch scraper issues with `IssueEntry` and signal `issueOccurred`
- log errors in a new `issues` table
- add issues tab to GUI and display issues as they occur
- track if database has prices and only scrape on first run

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684125f9afd48330bd703c90563b0d80