### PR TITLE
Implement first-run progress dialog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: price_tracker
-        path: dist/
+        name: Foodcoop
+        path: dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(FoodcoopPriceTracker VERSION 0.1 LANGUAGES CXX)
+project(Foodcoop VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_AUTOMOC ON)
@@ -8,19 +8,20 @@ set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Widgets Network Sql Charts)
 
-add_executable(price_tracker
+add_executable(Foodcoop
     src/main.cpp
     src/PriceFetcher.cpp
     src/DatabaseManager.cpp
     src/TrendDetector.cpp
     src/PlotWindow.cpp
+    src/FirstRunDialog.cpp
 )
 
-target_link_libraries(price_tracker PRIVATE
+target_link_libraries(Foodcoop PRIVATE
     Qt6::Widgets
     Qt6::Network
     Qt6::Sql
     Qt6::Charts
 )
 
-install(TARGETS price_tracker DESTINATION bin)
+install(TARGETS Foodcoop DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Foodcoop Price Tracker
+# Foodcoop
 
 This example Qt6 application fetches daily prices from Swiss grocery stores,
 stores them in a SQLite database and plots the price history. A simple trend
 detection is performed using linear regression on the stored prices.
 
-The `PriceFetcher` class now mimics a desktop browser when requesting product
-pages from Coop, Migros, Denner, Aldi Suisse and Lidl Suisse. Because the
-stores do not provide open APIs, the price is extracted from the HTML using a
-simple regular expression. The included URLs and regex patterns are examples and
-may require adjustment as the page markup changes.
+The `PriceFetcher` class mimics a desktop browser when scraping the Swiss stores
+(Coop, Migros, Denner, Aldi Suisse and Lidl Suisse). Product links are resolved
+dynamically by searching the site before fetching the product page. The resolved
+URL is stored in the SQLite database so the application can detect when a store
+moves a product and update the saved link automatically. The scraping code is
+intentionally simple and may require adjustments when the page markup changes.
 
 ## Building
 
@@ -19,4 +20,14 @@ cmake ..
 make
 ```
 
-Run the application with `./price_tracker`.
+Run the application with `./Foodcoop`.
+
+On the very first start the program shows a small progress dialog while it
+scrapes every configured store. A cancel button allows aborting the initial
+scrape and a toggle button reveals a debug log of the scraping process. The
+main window only appears once at least one price entry has been stored. On
+later runs prices are fetched silently in the background.
+
+New products can be added through the text field on the left side menu. The app
+will store the product URL for each store and automatically keep it updated when
+it changes.

--- a/src/DatabaseManager.cpp
+++ b/src/DatabaseManager.cpp
@@ -19,7 +19,9 @@ bool DatabaseManager::open(const QString &path)
         return false;
     }
     QSqlQuery query;
-    query.exec("CREATE TABLE IF NOT EXISTS prices (store TEXT, item TEXT, date TEXT, price REAL)");
+    query.exec("CREATE TABLE IF NOT EXISTS prices (store TEXT, item TEXT, date TEXT, price REAL, currency TEXT)");
+    query.exec("CREATE TABLE IF NOT EXISTS issues (store TEXT, item TEXT, date TEXT, error TEXT)");
+    query.exec("CREATE TABLE IF NOT EXISTS products (store TEXT, item TEXT, url TEXT, PRIMARY KEY(store, item))");
     return true;
 }
 
@@ -31,13 +33,27 @@ QString DatabaseManager::databasePath() const
 void DatabaseManager::insertPrice(const PriceEntry &entry)
 {
     QSqlQuery query;
-    query.prepare("INSERT INTO prices (store, item, date, price) VALUES (?, ?, ?, ?)");
+    query.prepare("INSERT INTO prices (store, item, date, price, currency) VALUES (?, ?, ?, ?, ?)");
     query.addBindValue(entry.store);
     query.addBindValue(entry.item);
     query.addBindValue(entry.date.toString(Qt::ISODate));
     query.addBindValue(entry.price);
+    query.addBindValue(entry.currency);
     if (!query.exec()) {
         qWarning() << "Insert failed" << query.lastError();
+    }
+}
+
+void DatabaseManager::insertIssue(const IssueEntry &issue)
+{
+    QSqlQuery query;
+    query.prepare("INSERT INTO issues (store, item, date, error) VALUES (?, ?, ?, ?)");
+    query.addBindValue(issue.store);
+    query.addBindValue(issue.item);
+    query.addBindValue(issue.date.toString(Qt::ISODate));
+    query.addBindValue(issue.error);
+    if (!query.exec()) {
+        qWarning() << "Insert issue failed" << query.lastError();
     }
 }
 
@@ -45,7 +61,7 @@ QList<PriceEntry> DatabaseManager::loadPrices(const QString &item, const QString
 {
     QList<PriceEntry> list;
     QSqlQuery query;
-    QString sql = "SELECT store, item, date, price FROM prices WHERE item = ?";
+    QString sql = "SELECT store, item, date, price, currency FROM prices WHERE item = ?";
     if (!store.isEmpty())
         sql += " AND store = ?";
     if (fromDate.isValid())
@@ -64,8 +80,24 @@ QList<PriceEntry> DatabaseManager::loadPrices(const QString &item, const QString
             entry.item = query.value(1).toString();
             entry.date = QDate::fromString(query.value(2).toString(), Qt::ISODate);
             entry.price = query.value(3).toDouble();
+            entry.currency = query.value(4).toString();
             list.append(entry);
         }
+    }
+    return list;
+}
+
+QList<IssueEntry> DatabaseManager::loadIssues() const
+{
+    QList<IssueEntry> list;
+    QSqlQuery query("SELECT store, item, date, error FROM issues ORDER BY date DESC");
+    while (query.next()) {
+        IssueEntry issue;
+        issue.store = query.value(0).toString();
+        issue.item = query.value(1).toString();
+        issue.date = QDate::fromString(query.value(2).toString(), Qt::ISODate);
+        issue.error = query.value(3).toString();
+        list.append(issue);
     }
     return list;
 }
@@ -74,7 +106,7 @@ PriceEntry DatabaseManager::latestPrice(const QString &item, const QString &stor
 {
     PriceEntry entry;
     QSqlQuery query;
-    query.prepare("SELECT store, item, date, price FROM prices WHERE item = ? AND store = ? ORDER BY date DESC LIMIT 1");
+    query.prepare("SELECT store, item, date, price, currency FROM prices WHERE item = ? AND store = ? ORDER BY date DESC LIMIT 1");
     query.addBindValue(item);
     query.addBindValue(store);
     if (query.exec() && query.next()) {
@@ -82,6 +114,57 @@ PriceEntry DatabaseManager::latestPrice(const QString &item, const QString &stor
         entry.item = query.value(1).toString();
         entry.date = QDate::fromString(query.value(2).toString(), Qt::ISODate);
         entry.price = query.value(3).toDouble();
+        entry.currency = query.value(4).toString();
     }
     return entry;
+}
+
+bool DatabaseManager::hasPrices() const
+{
+    QSqlQuery query("SELECT COUNT(*) FROM prices");
+    if (query.next())
+        return query.value(0).toInt() > 0;
+    return false;
+}
+
+void DatabaseManager::ensureProduct(const QString &store, const QString &item)
+{
+    QSqlQuery query;
+    query.prepare("INSERT OR IGNORE INTO products (store, item, url) VALUES (?, ?, '')");
+    query.addBindValue(store);
+    query.addBindValue(item);
+    if (!query.exec())
+        qWarning() << "ensureProduct failed" << query.lastError();
+}
+
+void DatabaseManager::setProductUrl(const QString &store, const QString &item, const QString &url)
+{
+    QSqlQuery query;
+    query.prepare("INSERT INTO products (store, item, url) VALUES (?, ?, ?) "
+                  "ON CONFLICT(store, item) DO UPDATE SET url=excluded.url");
+    query.addBindValue(store);
+    query.addBindValue(item);
+    query.addBindValue(url);
+    if (!query.exec())
+        qWarning() << "setProductUrl failed" << query.lastError();
+}
+
+QString DatabaseManager::productUrl(const QString &store, const QString &item) const
+{
+    QSqlQuery query;
+    query.prepare("SELECT url FROM products WHERE store=? AND item=?");
+    query.addBindValue(store);
+    query.addBindValue(item);
+    if (query.exec() && query.next())
+        return query.value(0).toString();
+    return QString();
+}
+
+QStringList DatabaseManager::loadItems() const
+{
+    QStringList list;
+    QSqlQuery query("SELECT DISTINCT item FROM products ORDER BY item");
+    while (query.next())
+        list.append(query.value(0).toString());
+    return list;
 }

--- a/src/DatabaseManager.h
+++ b/src/DatabaseManager.h
@@ -2,6 +2,7 @@
 #include <QObject>
 #include <QSqlDatabase>
 #include "PriceFetcher.h"
+#include <QStringList>
 
 class DatabaseManager : public QObject
 {
@@ -11,10 +12,17 @@ public:
     bool open(const QString &path);
     QString databasePath() const;
     void insertPrice(const PriceEntry &entry);
+    void insertIssue(const IssueEntry &issue);
+    QList<IssueEntry> loadIssues() const;
     QList<PriceEntry> loadPrices(const QString &item,
                                  const QString &store = QString(),
                                  const QDate &fromDate = QDate()) const;
     PriceEntry latestPrice(const QString &item, const QString &store) const;
+    bool hasPrices() const;
+    void ensureProduct(const QString &store, const QString &item);
+    void setProductUrl(const QString &store, const QString &item, const QString &url);
+    QString productUrl(const QString &store, const QString &item) const;
+    QStringList loadItems() const;
 
 private:
     QSqlDatabase m_db;

--- a/src/FirstRunDialog.cpp
+++ b/src/FirstRunDialog.cpp
@@ -1,0 +1,61 @@
+#include "FirstRunDialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+FirstRunDialog::FirstRunDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Initial Scrape"));
+    m_bar = new QProgressBar(this);
+    m_cancelButton = new QPushButton(tr("Cancel"), this);
+    m_toggleButton = new QPushButton(tr("Show Log"), this);
+    m_log = new QPlainTextEdit(this);
+    m_log->setReadOnly(true);
+    m_log->setVisible(false);
+
+    QHBoxLayout *btnLayout = new QHBoxLayout();
+    btnLayout->addWidget(m_cancelButton);
+    btnLayout->addWidget(m_toggleButton);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addWidget(m_bar);
+    layout->addLayout(btnLayout);
+    layout->addWidget(m_log);
+    setLayout(layout);
+
+    connect(m_cancelButton, &QPushButton::clicked, this, [this]() {
+        m_canceled = true;
+        emit canceled();
+    });
+
+    connect(m_toggleButton, &QPushButton::clicked, this, [this]() {
+        bool vis = !m_log->isVisible();
+        m_log->setVisible(vis);
+        m_toggleButton->setText(vis ? tr("Hide Log") : tr("Show Log"));
+    });
+}
+
+bool FirstRunDialog::isCanceled() const
+{
+    return m_canceled;
+}
+
+void FirstRunDialog::onProgress(int done, int total)
+{
+    m_bar->setMaximum(total);
+    m_bar->setValue(done);
+}
+
+void FirstRunDialog::onIssue(const IssueEntry &issue)
+{
+    m_log->appendPlainText(QString("%1|%2|%3|%4")
+                               .arg(issue.store)
+                               .arg(issue.item)
+                               .arg(issue.date.toString(Qt::ISODate))
+                               .arg(issue.error));
+}
+
+void FirstRunDialog::onFetchStarted()
+{
+    m_bar->setValue(0);
+}

--- a/src/FirstRunDialog.h
+++ b/src/FirstRunDialog.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <QDialog>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QPlainTextEdit>
+#include "PriceFetcher.h"
+
+class FirstRunDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit FirstRunDialog(QWidget *parent = nullptr);
+    bool isCanceled() const;
+
+public slots:
+    void onProgress(int done, int total);
+    void onIssue(const IssueEntry &issue);
+    void onFetchStarted();
+
+signals:
+    void canceled();
+
+private:
+    QProgressBar *m_bar;
+    QPushButton *m_cancelButton;
+    QPushButton *m_toggleButton;
+    QPlainTextEdit *m_log;
+    bool m_canceled = false;
+};

--- a/src/PlotWindow.cpp
+++ b/src/PlotWindow.cpp
@@ -12,6 +12,9 @@
 #include <QDateEdit>
 #include <QTabWidget>
 #include <QTableWidget>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QHBoxLayout>
 
 
 PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
@@ -26,9 +29,14 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     m_table->setColumnCount(2);
     m_table->setHorizontalHeaderLabels({tr("Date"), tr("Price")});
 
+    m_issueTable = new QTableWidget(this);
+    m_issueTable->setColumnCount(4);
+    m_issueTable->setHorizontalHeaderLabels({tr("Store"), tr("Item"), tr("Date"), tr("Error")});
+
     m_tabs = new QTabWidget(this);
     m_tabs->addTab(m_chartView, tr("Chart"));
     m_tabs->addTab(m_table, tr("Table"));
+    m_tabs->addTab(m_issueTable, tr("Issues"));
     setCentralWidget(m_tabs);
 
     // Create user menu dock
@@ -54,6 +62,17 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     dockLayout->addWidget(m_categoryCombo);
     connect(m_categoryCombo, &QComboBox::currentTextChanged, this, &PlotWindow::onCategoryChanged);
 
+    QHBoxLayout *addLayout = new QHBoxLayout();
+    m_newItemEdit = new QLineEdit(dockWidget);
+    m_addItemButton = new QPushButton(tr("Add"), dockWidget);
+    addLayout->addWidget(m_newItemEdit);
+    addLayout->addWidget(m_addItemButton);
+    dockLayout->addLayout(addLayout);
+    connect(m_addItemButton, &QPushButton::clicked, this, [this]() {
+        emit addItemRequested(m_newItemEdit->text());
+        m_newItemEdit->clear();
+    });
+
     dockLayout->addWidget(new QLabel(tr("From:"), dockWidget));
     m_fromDateEdit = new QDateEdit(QDate::currentDate().addDays(-30), dockWidget);
     m_fromDateEdit->setCalendarPopup(true);
@@ -70,6 +89,7 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     m_currentStore = m_storeCombo->currentText();
     m_currentCategory = m_categoryCombo->currentText();
     updateDbInfo();
+    updateIssues();
 
     m_timer = new QTimer(this);
     connect(m_timer, &QTimer::timeout, this, &PlotWindow::updateChart);
@@ -93,13 +113,14 @@ void PlotWindow::updateChart()
     m_table->setRowCount(prices.size());
     for (int i = 0; i < prices.size(); ++i) {
         m_table->setItem(i, 0, new QTableWidgetItem(prices[i].date.toString(Qt::ISODate)));
-        m_table->setItem(i, 1, new QTableWidgetItem(QString::number(prices[i].price)));
+        m_table->setItem(i, 1, new QTableWidgetItem(QString("%1 %2").arg(prices[i].price).arg(prices[i].currency)));
     }
 
     PriceEntry latest = m_db->latestPrice(m_currentCategory, m_currentStore);
     if (latest.date.isValid())
-        m_currentPriceLabel->setText(tr("Current price: %1 (%2)")
+        m_currentPriceLabel->setText(tr("Current price: %1 %2 (%3)")
                                         .arg(latest.price)
+                                        .arg(latest.currency)
                                         .arg(latest.date.toString(Qt::ISODate)));
     else
         m_currentPriceLabel->setText(tr("Current price: N/A"));
@@ -126,11 +147,34 @@ void PlotWindow::onFetchFinished()
 {
     m_browserStatusLabel->setText(tr("Browser: Idle"));
     updateDbInfo();
+    updateIssues();
 }
 
 void PlotWindow::onFromDateChanged(const QDate &)
 {
     updateChart();
+}
+
+void PlotWindow::onIssueOccurred(const IssueEntry &issue)
+{
+    int row = m_issueTable->rowCount();
+    m_issueTable->insertRow(row);
+    m_issueTable->setItem(row, 0, new QTableWidgetItem(issue.store));
+    m_issueTable->setItem(row, 1, new QTableWidgetItem(issue.item));
+    m_issueTable->setItem(row, 2, new QTableWidgetItem(issue.date.toString(Qt::ISODate)));
+    m_issueTable->setItem(row, 3, new QTableWidgetItem(issue.error));
+}
+
+void PlotWindow::updateIssues()
+{
+    QList<IssueEntry> issues = m_db->loadIssues();
+    m_issueTable->setRowCount(issues.size());
+    for (int i = 0; i < issues.size(); ++i) {
+        m_issueTable->setItem(i, 0, new QTableWidgetItem(issues[i].store));
+        m_issueTable->setItem(i, 1, new QTableWidgetItem(issues[i].item));
+        m_issueTable->setItem(i, 2, new QTableWidgetItem(issues[i].date.toString(Qt::ISODate)));
+        m_issueTable->setItem(i, 3, new QTableWidgetItem(issues[i].error));
+    }
 }
 
 void PlotWindow::updateDbInfo()
@@ -139,8 +183,9 @@ void PlotWindow::updateDbInfo()
     m_dbSizeLabel->setText(tr("Database size: %1 KB").arg(info.size() / 1024));
     PriceEntry latest = m_db->latestPrice(m_currentCategory, m_currentStore);
     if (latest.date.isValid())
-        m_currentPriceLabel->setText(tr("Current price: %1 (%2)")
+        m_currentPriceLabel->setText(tr("Current price: %1 %2 (%3)")
                                         .arg(latest.price)
+                                        .arg(latest.currency)
                                         .arg(latest.date.toString(Qt::ISODate)));
     else
         m_currentPriceLabel->setText(tr("Current price: N/A"));

--- a/src/PlotWindow.h
+++ b/src/PlotWindow.h
@@ -10,6 +10,8 @@
 #include <QDateEdit>
 #include <QTabWidget>
 #include <QTableWidget>
+#include <QLineEdit>
+#include <QPushButton>
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -29,7 +31,12 @@ public slots:
     void onCategoryChanged(const QString &category);
     void onFetchStarted();
     void onFetchFinished();
+    void onIssueOccurred(const IssueEntry &issue);
     void onFromDateChanged(const QDate &date);
+    void updateIssues();
+
+signals:
+    void addItemRequested(const QString &item);
 
 private:
     DatabaseManager *m_db;
@@ -37,6 +44,7 @@ private:
     QChartView *m_chartView;
     QLineSeries *m_series;
     QTableWidget *m_table;
+    QTableWidget *m_issueTable;
     QTabWidget *m_tabs;
     QTimer *m_timer;
     QDockWidget *m_menuDock;
@@ -45,6 +53,8 @@ private:
     QLabel *m_browserStatusLabel;
     QComboBox *m_storeCombo;
     QComboBox *m_categoryCombo;
+    QLineEdit *m_newItemEdit;
+    QPushButton *m_addItemButton;
     QDateEdit *m_fromDateEdit;
     QString m_currentStore;
     QString m_currentCategory;

--- a/src/PriceFetcher.cpp
+++ b/src/PriceFetcher.cpp
@@ -1,57 +1,82 @@
 #include "PriceFetcher.h"
+#include "DatabaseManager.h"
 #include <QRegularExpression>
 #include <QDate>
 #include <QUrl>
 
-PriceFetcher::PriceFetcher(QObject *parent)
-    : QObject(parent)
+PriceFetcher::PriceFetcher(DatabaseManager *db, QObject *parent)
+    : QObject(parent), m_db(db)
 {
     connect(&m_manager, &QNetworkAccessManager::finished,
             this, &PriceFetcher::onReply);
 
-    // Example product pages. These URLs are publicly accessible HTML pages and
-    // not official API endpoints. We request them with a desktop User-Agent and
-    // extract the price using a regular expression. The regex patterns are
-    // simple and may need adjustment if the page structure changes.
-    m_products = {
-        {"Coop", "Milk",
-         "https://www.coop.ch/en/shop/getraenke/milch/coop-milch-35-/p/614300600000",
-         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
-        {"Migros", "Milk",
-         "https://produkte.migros.ch/migros-milch-vollmilch",
-         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
-        {"Denner", "Milk",
-         "https://www.denner.ch/de/shop/getraenke/milch/p/30700/",
-         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
-        {"Aldi Suisse", "Milk",
-         "https://www.aldi-suisse.ch/de/sortiment/kuhlprodukte/milch/p/10203/",
-         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")},
-        {"Lidl Suisse", "Milk",
-         "https://www.lidl.ch/de/Milch/p1000",
-         QRegularExpression("price[^0-9]*([0-9]+\\.[0-9]{2})")}
+    // Configure stores and a generic product to track. The URLs are templates
+    // for a search query. We will dynamically extract the first product link and
+    // then scrape its price.
+    m_stores = {
+        {"Coop",
+         "https://www.coop.ch/en/search/?text=%1",
+         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
+         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
+        {"Migros",
+         "https://www.migros.ch/de/search?q=%1",
+         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
+         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
+        {"Denner",
+         "https://www.denner.ch/de/suche/?q=%1",
+         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
+         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
+        {"Aldi Suisse",
+         "https://www.aldi-suisse.ch/de/suchergebnis.html?search=%1",
+         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
+         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
+        {"Lidl Suisse",
+         "https://www.lidl.ch/sr?query=%1",
+         QRegularExpression(R"(href=\"([^\"]+/p\d+)\")"),
+         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
     };
+
+    if (m_db) {
+        m_items = m_db->loadItems();
+        if (m_items.isEmpty())
+            m_items = {"Milk"};
+        for (const StoreInfo &info : m_stores)
+            for (const QString &item : m_items)
+                m_db->ensureProduct(info.store, item);
+    } else {
+        m_items = {"Milk"};
+    }
 }
 
 void PriceFetcher::fetchDailyPrices()
 {
-    m_pending = m_products.size();
+    m_total = m_stores.size() * m_items.size();
+    m_pending = m_total;
     emit fetchStarted();
-    for (const StoreProduct &p : m_products) {
-        QNetworkRequest request(QUrl(p.url));
-        request.setHeader(QNetworkRequest::UserAgentHeader,
-                          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                          "(KHTML, like Gecko) Chrome/120.0 Safari/537.36");
-        QNetworkReply *reply = m_manager.get(request);
-        reply->setProperty("store", p.store);
-        reply->setProperty("item", p.item);
-        reply->setProperty("regex", p.priceRegex.pattern());
+    emit progressChanged(0, m_total);
+
+    for (const StoreInfo &info : m_stores) {
+        for (const QString &item : m_items) {
+            QUrl url(info.searchUrl.arg(QUrl::toPercentEncoding(item)));
+            QNetworkRequest request(url);
+            request.setHeader(QNetworkRequest::UserAgentHeader,
+                              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                              "AppleWebKit/537.36 (KHTML, like Gecko) "
+                              "Chrome/120.0 Safari/537.36");
+            QNetworkReply *reply = m_manager.get(request);
+            reply->setProperty("store", info.store);
+            reply->setProperty("item", item);
+            reply->setProperty("stage", static_cast<int>(RequestStage::Search));
+            reply->setProperty("priceRegex", info.priceRegex.pattern());
+            reply->setProperty("productRegex", info.productRegex.pattern());
+        }
     }
 }
 
 QStringList PriceFetcher::storeList() const
 {
     QStringList list;
-    for (const StoreProduct &p : m_products) {
+    for (const StoreInfo &p : m_stores) {
         if (!list.contains(p.store))
             list.append(p.store);
     }
@@ -60,12 +85,19 @@ QStringList PriceFetcher::storeList() const
 
 QStringList PriceFetcher::categoryList() const
 {
-    QStringList list;
-    for (const StoreProduct &p : m_products) {
-        if (!list.contains(p.item))
-            list.append(p.item);
+    return m_items;
+}
+
+void PriceFetcher::addItem(const QString &item)
+{
+    if (m_items.contains(item))
+        return;
+    m_items.append(item);
+    if (m_db) {
+        for (const StoreInfo &info : m_stores)
+            m_db->ensureProduct(info.store, item);
     }
-    return list;
+    emit itemListChanged();
 }
 
 void PriceFetcher::onReply(QNetworkReply *reply)
@@ -75,18 +107,91 @@ void PriceFetcher::onReply(QNetworkReply *reply)
     entry.item = reply->property("item").toString();
     entry.date = QDate::currentDate();
     entry.price = 0.0;
+    entry.currency = QStringLiteral("CHF");
 
-    const QByteArray data = reply->readAll();
-    QString pattern = reply->property("regex").toString();
-    QRegularExpression regex(pattern);
-    QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
-    if (match.hasMatch())
-        entry.price = match.captured(1).toDouble();
+    IssueEntry issue;
+    issue.store = entry.store;
+    issue.item = entry.item;
+    issue.date = entry.date;
 
-    emit priceFetched(entry);
+    if (reply->error() != QNetworkReply::NoError) {
+        issue.error = reply->errorString();
+        emit issueOccurred(issue);
+        if (--m_pending == 0) {
+            emit progressChanged(m_total - m_pending, m_total);
+            emit fetchFinished();
+        } else {
+            emit progressChanged(m_total - m_pending, m_total);
+        }
+        reply->deleteLater();
+        return;
+    }
 
-    if (--m_pending == 0)
-        emit fetchFinished();
+    QByteArray data = reply->readAll();
+    RequestStage stage = static_cast<RequestStage>(reply->property("stage").toInt());
+
+    if (stage == RequestStage::Search) {
+        QRegularExpression regex(reply->property("productRegex").toString());
+        QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
+        if (match.hasMatch()) {
+            QUrl next = reply->url().resolved(QUrl(match.captured(1)));
+            if (m_db)
+                m_db->setProductUrl(entry.store, entry.item, next.toString());
+            QNetworkRequest req(next);
+            req.setHeader(QNetworkRequest::UserAgentHeader,
+                          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                          "AppleWebKit/537.36 (KHTML, like Gecko) "
+                          "Chrome/120.0 Safari/537.36");
+            QNetworkReply *nr = m_manager.get(req);
+            nr->setProperty("store", entry.store);
+            nr->setProperty("item", entry.item);
+            nr->setProperty("stage", static_cast<int>(RequestStage::Product));
+            nr->setProperty("priceRegex", reply->property("priceRegex").toString());
+        } else {
+            QString storedUrl = m_db ? m_db->productUrl(entry.store, entry.item) : QString();
+            if (!storedUrl.isEmpty()) {
+                QNetworkRequest req{QUrl(storedUrl)};
+                req.setHeader(QNetworkRequest::UserAgentHeader,
+                              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                              "AppleWebKit/537.36 (KHTML, like Gecko) "
+                              "Chrome/120.0 Safari/537.36");
+                QNetworkReply *nr = m_manager.get(req);
+                nr->setProperty("store", entry.store);
+                nr->setProperty("item", entry.item);
+                nr->setProperty("stage", static_cast<int>(RequestStage::Product));
+                nr->setProperty("priceRegex", reply->property("priceRegex").toString());
+                issue.error = QStringLiteral("Used stored URL");
+                emit issueOccurred(issue);
+            } else {
+                issue.error = QStringLiteral("Product not found");
+                emit issueOccurred(issue);
+                if (--m_pending == 0) {
+                    emit progressChanged(m_total - m_pending, m_total);
+                    emit fetchFinished();
+                } else {
+                    emit progressChanged(m_total - m_pending, m_total);
+                }
+            }
+        }
+    } else {
+        if (m_db)
+            m_db->setProductUrl(entry.store, entry.item, reply->url().toString());
+        QRegularExpression regex(reply->property("priceRegex").toString());
+        QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
+        if (match.hasMatch()) {
+            entry.price = match.captured(1).toDouble();
+            emit priceFetched(entry);
+        } else {
+            issue.error = QStringLiteral("Price not found");
+            emit issueOccurred(issue);
+        }
+        if (--m_pending == 0) {
+            emit progressChanged(m_total - m_pending, m_total);
+            emit fetchFinished();
+        } else {
+            emit progressChanged(m_total - m_pending, m_total);
+        }
+    }
 
     reply->deleteLater();
 }

--- a/src/PriceFetcher.h
+++ b/src/PriceFetcher.h
@@ -5,39 +5,60 @@
 #include <QList>
 #include <QUrl>
 #include <QRegularExpression>
+#include <QDate>
 
 struct PriceEntry {
     QString store;
     QString item;
     QDate date;
     double price;
+    QString currency;
 };
+
+struct IssueEntry {
+    QString store;
+    QString item;
+    QDate date;
+    QString error;
+};
+
+class DatabaseManager;
 
 class PriceFetcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit PriceFetcher(QObject *parent = nullptr);
+    explicit PriceFetcher(DatabaseManager *db, QObject *parent = nullptr);
     void fetchDailyPrices();
     QStringList storeList() const;
     QStringList categoryList() const;
+    void addItem(const QString &item);
 
 signals:
     void priceFetched(const PriceEntry &entry);
+    void issueOccurred(const IssueEntry &issue);
     void fetchFinished();
     void fetchStarted();
+    void progressChanged(int done, int total);
+    void itemListChanged();
 
 private slots:
     void onReply(QNetworkReply *reply);
 
 private:
-    struct StoreProduct {
+    enum class RequestStage { Search, Product };
+
+    struct StoreInfo {
         QString store;
-        QString item;
-        QString url;
-        QRegularExpression priceRegex;
+        QString searchUrl;          // use %1 for item
+        QRegularExpression productRegex; // extracts product URL from search page
+        QRegularExpression priceRegex;   // extracts price from product page
     };
-    QList<StoreProduct> m_products;
+
+    QList<StoreInfo> m_stores;
+    QStringList m_items;
     int m_pending = 0;
+    int m_total = 0;
     QNetworkAccessManager m_manager;
+    DatabaseManager *m_db = nullptr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,27 +2,72 @@
 #include "PriceFetcher.h"
 #include "DatabaseManager.h"
 #include "PlotWindow.h"
+#include "FirstRunDialog.h"
+#include <QEventLoop>
+
+static bool performFirstScrape(PriceFetcher &fetcher, DatabaseManager &db)
+{
+    FirstRunDialog dialog;
+    QObject::connect(&fetcher, &PriceFetcher::progressChanged,
+                     &dialog, &FirstRunDialog::onProgress);
+    QObject::connect(&fetcher, &PriceFetcher::issueOccurred,
+                     &dialog, &FirstRunDialog::onIssue);
+    QObject::connect(&fetcher, &PriceFetcher::fetchStarted,
+                     &dialog, &FirstRunDialog::onFetchStarted);
+
+    bool canceled = false;
+    QObject::connect(&dialog, &FirstRunDialog::canceled, [&](){ canceled = true; });
+    dialog.show();
+
+    while (!db.hasPrices() && !canceled) {
+        QEventLoop loop;
+        QObject::connect(&fetcher, &PriceFetcher::fetchFinished,
+                         &loop, &QEventLoop::quit);
+        fetcher.fetchDailyPrices();
+        loop.exec();
+    }
+
+    dialog.hide();
+    return db.hasPrices() && !canceled;
+}
 
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    QApplication::setApplicationName("Foodcoop");
 
     DatabaseManager db;
     db.open("prices.db");
 
     PlotWindow w(&db);
-    w.show();
 
-    PriceFetcher fetcher;
+    PriceFetcher fetcher(&db);
     w.setStoreList(fetcher.storeList());
     w.setCategoryList(fetcher.categoryList());
     QObject::connect(&fetcher, &PriceFetcher::priceFetched,
                      [&db](const PriceEntry &entry){ db.insertPrice(entry); });
+    QObject::connect(&fetcher, &PriceFetcher::issueOccurred,
+                     [&db, &w](const IssueEntry &issue){
+                         db.insertIssue(issue);
+                         w.onIssueOccurred(issue);
+                     });
     QObject::connect(&fetcher, &PriceFetcher::fetchStarted,
                      &w, &PlotWindow::onFetchStarted);
     QObject::connect(&fetcher, &PriceFetcher::fetchFinished,
                      &w, &PlotWindow::onFetchFinished);
-    fetcher.fetchDailyPrices();
+    QObject::connect(&w, &PlotWindow::addItemRequested,
+                     &fetcher, &PriceFetcher::addItem);
+    QObject::connect(&fetcher, &PriceFetcher::itemListChanged,
+                     [&w, &fetcher]() {
+                         w.setCategoryList(fetcher.categoryList());
+                         w.updateChart();
+                     });
+    if (!db.hasPrices()) {
+        if (!performFirstScrape(fetcher, db))
+            return 0;
+    }
+
+    w.show();
 
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- show a progress dialog with debug log while scraping data for the first run
- report fetch progress via new `progressChanged` signal
- record scraping issues in the dialog log
- describe first-run dialog in the README

## Testing
- `cmake .. && cmake --build . -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684125f9afd48330bd703c90563b0d80