### PR TITLE
Improve scraping and remove hardcoded item

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets Network Sql Charts)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Network Sql Charts WebEngineCore WebEngineQuick)
 
 add_executable(Foodcoop
     src/main.cpp
@@ -22,6 +22,25 @@ target_link_libraries(Foodcoop PRIVATE
     Qt6::Network
     Qt6::Sql
     Qt6::Charts
+    Qt6::WebEngineCore
+    Qt6::WebEngineQuick
 )
 
 install(TARGETS Foodcoop DESTINATION bin)
+
+add_executable(fetch_test
+    fetch_test.cpp
+    src/PriceFetcher.cpp
+    src/DatabaseManager.cpp
+)
+
+target_include_directories(fetch_test PRIVATE src)
+
+target_link_libraries(fetch_test PRIVATE
+    Qt6::Network
+    Qt6::Sql
+    Qt6::WebEngineCore
+    Qt6::WebEngineQuick
+)
+
+install(TARGETS fetch_test DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ stores them in a SQLite database and plots the price history. A simple trend
 detection is performed using linear regression on the stored prices.
 
 The `PriceFetcher` class mimics a desktop browser when scraping the Swiss stores
-(Coop, Migros, Denner, Aldi Suisse, Lidl Suisse and Ottos Warenposten). Product links are resolved
+(Coop, Migros, Denner, Aldi Suisse, Lidl Suisse and Ottos Warenposten). When a site requires JavaScript, a headless QtWebEngine page is used automatically. Product links are resolved
 dynamically by searching the site before fetching the product page. The resolved
 URL is stored in the SQLite database so the application can detect when a store
 moves a product and update the saved link automatically. The scraping code is

--- a/fetch_test.cpp
+++ b/fetch_test.cpp
@@ -1,0 +1,26 @@
+#include <QGuiApplication>
+#include <QtWebEngineQuick/qtwebenginequickglobal.h>
+#include "DatabaseManager.h"
+#include "PriceFetcher.h"
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
+    qputenv("QTWEBENGINE_DISABLE_SANDBOX", QByteArray("1"));
+    qputenv("QT_OPENGL", QByteArray("software"));
+    QtWebEngineQuick::initialize();
+    QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
+    QGuiApplication app(argc, argv);
+
+    DatabaseManager db;
+    db.open("test.db");
+
+    PriceFetcher fetcher(&db);
+    const QStringList args = app.arguments();
+    for (int i = 1; i < args.size(); ++i)
+        fetcher.addItem(args.at(i));
+    QObject::connect(&fetcher, &PriceFetcher::fetchFinished,
+                     &app, &QGuiApplication::quit);
+    fetcher.fetchDailyPrices();
+    return app.exec();
+}

--- a/src/PlotWindow.cpp
+++ b/src/PlotWindow.cpp
@@ -76,7 +76,6 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
 
     dockLayout->addWidget(new QLabel(tr("Category:"), dockWidget));
     m_categoryCombo = new QComboBox(dockWidget);
-    m_categoryCombo->addItems({"Milk"});
     dockLayout->addWidget(m_categoryCombo);
     connect(m_categoryCombo, &QComboBox::currentTextChanged, this, &PlotWindow::onCategoryChanged);
 

--- a/src/PriceFetcher.cpp
+++ b/src/PriceFetcher.cpp
@@ -3,52 +3,51 @@
 #include <QRegularExpression>
 #include <QDate>
 #include <QUrl>
+#include <QWebEngineProfile>
+#include <QWebEnginePage>
+
+#include <QtWebEngineQuick/qtwebenginequickglobal.h>
 
 PriceFetcher::PriceFetcher(DatabaseManager *db, QObject *parent)
     : QObject(parent), m_db(db)
 {
     connect(&m_manager, &QNetworkAccessManager::finished,
             this, &PriceFetcher::onReply);
+    connect(&m_manager, &QNetworkAccessManager::sslErrors,
+            this, [](QNetworkReply *reply, const QList<QSslError> &){
+                reply->ignoreSslErrors();
+            });
+    connect(&m_page, &QWebEnginePage::loadFinished,
+            this, &PriceFetcher::onBrowserLoadFinished);
+    connect(&m_page, &QWebEnginePage::certificateError,
+            this, [](const QWebEngineCertificateError &error){
+                Q_UNUSED(error);
+                return true;
+            });
 
     // Configure stores and a generic product to track. The URLs are templates
     // for a search query. We will dynamically extract the first product link and
     // then scrape its price.
+    QRegularExpression productRe{R"(href=['"]([^'" ]*/p[^'" ]+)['"])"};
+    QRegularExpression priceRe{R"(price[^0-9]*([0-9]+\.[0-9]{2}))"};
+
     m_stores = {
-        {"Coop",
-         "https://www.coop.ch/en/search/?text=%1",
-         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
-         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
-        {"Migros",
-         "https://www.migros.ch/de/search?q=%1",
-         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
-         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
-        {"Denner",
-         "https://www.denner.ch/de/suche/?q=%1",
-         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
-         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
-        {"Aldi Suisse",
-         "https://www.aldi-suisse.ch/de/suchergebnis.html?search=%1",
-         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
-         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
-        {"Lidl Suisse",
-         "https://www.lidl.ch/sr?query=%1",
-         QRegularExpression(R"(href=\"([^\"]+/p\d+)\")"),
-         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
-        {"Ottos Warenposten",
-         "https://www.ottos.ch/de/search?search=%1",
-         QRegularExpression(R"(href=\"([^\"]+/p/\d+)\")"),
-         QRegularExpression(R"(price[^0-9]*([0-9]+\.[0-9]{2}))")},
+        {"Coop", "https://www.coop.ch/de/search/?text=%1", productRe, priceRe},
+        {"Migros", "https://www.migros.ch/en/search?query=%1", productRe, priceRe},
+        {"Denner", "https://www.denner.ch/de/search?q=%1", productRe, priceRe},
+        {"Aldi Suisse", "https://www.aldi-now.ch/de/search?q=%1", productRe,
+         priceRe},
+        {"Lidl Suisse", "https://www.lidl.ch/q/de-CH/search?q=%1", productRe,
+         priceRe},
+        {"Ottos Warenposten", "https://www.ottos.ch/de/search/%1", productRe,
+         priceRe},
     };
 
     if (m_db) {
         m_items = m_db->loadItems();
-        if (m_items.isEmpty())
-            m_items = {"Milk"};
         for (const StoreInfo &info : m_stores)
             for (const QString &item : m_items)
                 m_db->ensureProduct(info.store, item);
-    } else {
-        m_items = {"Milk"};
     }
 }
 
@@ -59,21 +58,44 @@ void PriceFetcher::fetchDailyPrices()
     emit fetchStarted();
     emit progressChanged(0, m_total);
 
+    if (m_total == 0) {
+        emit fetchFinished();
+        return;
+    }
+
     for (const StoreInfo &info : m_stores) {
         for (const QString &item : m_items) {
-            QUrl url(info.searchUrl.arg(QUrl::toPercentEncoding(item)));
-            QNetworkRequest request(url);
-            request.setHeader(QNetworkRequest::UserAgentHeader,
+            QString storedUrl = m_db ? m_db->productUrl(info.store, item) : QString();
+            if (!storedUrl.isEmpty()) {
+                QNetworkRequest req{QUrl(storedUrl)};
+                req.setHeader(QNetworkRequest::UserAgentHeader,
                               "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                               "AppleWebKit/537.36 (KHTML, like Gecko) "
                               "Chrome/120.0 Safari/537.36");
-            request.setRawHeader("Accept-Language", "de-CH,de;q=0.9,en;q=0.8");
-            QNetworkReply *reply = m_manager.get(request);
-            reply->setProperty("store", info.store);
-            reply->setProperty("item", item);
-            reply->setProperty("stage", static_cast<int>(RequestStage::Search));
-            reply->setProperty("priceRegex", info.priceRegex.pattern());
-            reply->setProperty("productRegex", info.productRegex.pattern());
+                req.setRawHeader("Accept-Language", "de-CH,de;q=0.9,en;q=0.8");
+                QNetworkReply *reply = m_manager.get(req);
+                reply->setProperty("store", info.store);
+                reply->setProperty("item", item);
+                reply->setProperty("stage", static_cast<int>(RequestStage::Product));
+                reply->setProperty("priceRegex", info.priceRegex.pattern());
+                reply->setProperty("productRegex", info.productRegex.pattern());
+                reply->setProperty("searchUrl", info.searchUrl);
+            } else {
+                QUrl url(info.searchUrl.arg(QUrl::toPercentEncoding(item)));
+                QNetworkRequest request(url);
+                request.setHeader(QNetworkRequest::UserAgentHeader,
+                                  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                  "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                  "Chrome/120.0 Safari/537.36");
+                request.setRawHeader("Accept-Language", "de-CH,de;q=0.9,en;q=0.8");
+                QNetworkReply *reply = m_manager.get(request);
+                reply->setProperty("store", info.store);
+                reply->setProperty("item", item);
+                reply->setProperty("stage", static_cast<int>(RequestStage::Search));
+                reply->setProperty("priceRegex", info.priceRegex.pattern());
+                reply->setProperty("productRegex", info.productRegex.pattern());
+                reply->setProperty("searchUrl", info.searchUrl);
+            }
         }
     }
 }
@@ -119,36 +141,28 @@ void PriceFetcher::onReply(QNetworkReply *reply)
     issue.item = entry.item;
     issue.date = entry.date;
 
+    QByteArray data = reply->readAll();
+    RequestStage stage = static_cast<RequestStage>(reply->property("stage").toInt());
+
+    bool success = false;
+
     if (reply->error() != QNetworkReply::NoError) {
         issue.error = reply->errorString();
         emit issueOccurred(issue);
-        if (--m_pending == 0) {
-            emit progressChanged(m_total - m_pending, m_total);
-            emit fetchFinished();
-        } else {
-            emit progressChanged(m_total - m_pending, m_total);
-        }
-        reply->deleteLater();
-        return;
-
-    } else {
-        const QByteArray data = reply->readAll();
-        QString pattern = reply->property("regex").toString();
-        QRegularExpression regex(pattern);
+    } else if (stage == RequestStage::Product) {
+        QRegularExpression regex(reply->property("priceRegex").toString());
         QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
         if (match.hasMatch()) {
             entry.price = match.captured(1).toDouble();
             emit priceFetched(entry);
+            if (m_db)
+                m_db->setProductUrl(entry.store, entry.item, reply->url().toString());
+            success = true;
         } else {
             issue.error = QStringLiteral("Price not found");
             emit issueOccurred(issue);
         }
-    }
-
-    QByteArray data = reply->readAll();
-    RequestStage stage = static_cast<RequestStage>(reply->property("stage").toInt());
-
-    if (stage == RequestStage::Search) {
+    } else if (stage == RequestStage::Search) {
         QRegularExpression regex(reply->property("productRegex").toString());
         QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
         if (match.hasMatch()) {
@@ -166,52 +180,164 @@ void PriceFetcher::onReply(QNetworkReply *reply)
             nr->setProperty("item", entry.item);
             nr->setProperty("stage", static_cast<int>(RequestStage::Product));
             nr->setProperty("priceRegex", reply->property("priceRegex").toString());
+            nr->setProperty("productRegex", reply->property("productRegex").toString());
+            nr->setProperty("searchUrl", reply->property("searchUrl").toString());
+            reply->deleteLater();
+            return;
         } else {
-            QString storedUrl = m_db ? m_db->productUrl(entry.store, entry.item) : QString();
-            if (!storedUrl.isEmpty()) {
-                QNetworkRequest req{QUrl(storedUrl)};
-                req.setHeader(QNetworkRequest::UserAgentHeader,
-                              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                              "AppleWebKit/537.36 (KHTML, like Gecko) "
-                              "Chrome/120.0 Safari/537.36");
-                req.setRawHeader("Accept-Language", "de-CH,de;q=0.9,en;q=0.8");
-                QNetworkReply *nr = m_manager.get(req);
-                nr->setProperty("store", entry.store);
-                nr->setProperty("item", entry.item);
-                nr->setProperty("stage", static_cast<int>(RequestStage::Product));
-                nr->setProperty("priceRegex", reply->property("priceRegex").toString());
-                issue.error = QStringLiteral("Used stored URL");
-                emit issueOccurred(issue);
-            } else {
-                issue.error = QStringLiteral("Product not found");
-                emit issueOccurred(issue);
-                if (--m_pending == 0) {
-                    emit progressChanged(m_total - m_pending, m_total);
-                    emit fetchFinished();
-                } else {
-                    emit progressChanged(m_total - m_pending, m_total);
-                }
-            }
-        }
-    } else {
-        if (m_db)
-            m_db->setProductUrl(entry.store, entry.item, reply->url().toString());
-        QRegularExpression regex(reply->property("priceRegex").toString());
-        QRegularExpressionMatch match = regex.match(QString::fromUtf8(data));
-        if (match.hasMatch()) {
-            entry.price = match.captured(1).toDouble();
-            emit priceFetched(entry);
-        } else {
-            issue.error = QStringLiteral("Price not found");
+            issue.error = QStringLiteral("Product not found");
             emit issueOccurred(issue);
         }
+    }
+
+    if (!success && stage == RequestStage::Product) {
+        QString searchUrl = reply->property("searchUrl").toString();
+        if (!searchUrl.isEmpty()) {
+            QUrl url(searchUrl.arg(QUrl::toPercentEncoding(entry.item)));
+            QNetworkRequest req(url);
+            req.setHeader(QNetworkRequest::UserAgentHeader,
+                          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                          "AppleWebKit/537.36 (KHTML, like Gecko) "
+                          "Chrome/120.0 Safari/537.36");
+            req.setRawHeader("Accept-Language", "de-CH,de;q=0.9,en;q=0.8");
+            QNetworkReply *nr = m_manager.get(req);
+            nr->setProperty("store", entry.store);
+            nr->setProperty("item", entry.item);
+            nr->setProperty("stage", static_cast<int>(RequestStage::Search));
+            nr->setProperty("priceRegex", reply->property("priceRegex").toString());
+            nr->setProperty("productRegex", reply->property("productRegex").toString());
+            nr->setProperty("searchUrl", searchUrl);
+            reply->deleteLater();
+            emit issueOccurred(issue); // log failure before retrying
+            return;
+        }
+    }
+
+    if (!success) {
+        BrowserRequest br;
+        br.url = reply->url();
+        br.store = entry.store;
+        br.item = entry.item;
+        br.priceRegex = reply->property("priceRegex").toString();
+        br.productRegex = reply->property("productRegex").toString();
+        br.stage = stage;
+        br.searchUrl = reply->property("searchUrl").toString();
+        enqueueBrowserRequest(br);
+        reply->deleteLater();
+        return;
+    }
+
+    if (--m_pending == 0) {
+        emit progressChanged(m_total - m_pending, m_total);
+        emit fetchFinished();
+    } else {
+        emit progressChanged(m_total - m_pending, m_total);
+    }
+
+    reply->deleteLater();
+}
+
+void PriceFetcher::enqueueBrowserRequest(const BrowserRequest &req)
+{
+    m_browserQueue.enqueue(req);
+    if (!m_browserBusy)
+        startNextBrowserRequest();
+}
+
+void PriceFetcher::startNextBrowserRequest()
+{
+    if (m_browserQueue.isEmpty()) {
+        m_browserBusy = false;
+        return;
+    }
+    m_browserBusy = true;
+    m_currentRequest = m_browserQueue.dequeue();
+    QWebEngineHttpRequest req(m_currentRequest.url);
+    req.setHeader("User-Agent",
+                  QByteArray("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                             "AppleWebKit/537.36 (KHTML, like Gecko) "
+                             "Chrome/120.0 Safari/537.36"));
+    m_page.load(req);
+}
+
+void PriceFetcher::onBrowserLoadFinished(bool ok)
+{
+    if (!ok) {
+        IssueEntry issue;
+        issue.store = m_currentRequest.store;
+        issue.item = m_currentRequest.item;
+        issue.date = QDate::currentDate();
+        issue.error = QStringLiteral("Browser load failed");
+        emit issueOccurred(issue);
+        startNextBrowserRequest();
         if (--m_pending == 0) {
             emit progressChanged(m_total - m_pending, m_total);
             emit fetchFinished();
         } else {
             emit progressChanged(m_total - m_pending, m_total);
         }
+        return;
     }
 
-    reply->deleteLater();
+    m_page.toHtml([this](const QString &html) { onBrowserHtmlReady(html); });
+}
+
+void PriceFetcher::onBrowserHtmlReady(const QString &html)
+{
+    PriceEntry entry;
+    entry.store = m_currentRequest.store;
+    entry.item = m_currentRequest.item;
+    entry.date = QDate::currentDate();
+    entry.price = 0.0;
+    entry.currency = QStringLiteral("CHF");
+
+    IssueEntry issue;
+    issue.store = entry.store;
+    issue.item = entry.item;
+    issue.date = entry.date;
+
+    if (m_currentRequest.stage == RequestStage::Product) {
+        QRegularExpression regex(m_currentRequest.priceRegex);
+        QRegularExpressionMatch match = regex.match(html);
+        if (match.hasMatch()) {
+            entry.price = match.captured(1).toDouble();
+            emit priceFetched(entry);
+            if (m_db)
+                m_db->setProductUrl(entry.store, entry.item, m_currentRequest.url.toString());
+        } else {
+            issue.error = QStringLiteral("Price not found");
+            emit issueOccurred(issue);
+        }
+    } else {
+        QRegularExpression regex(m_currentRequest.productRegex);
+        QRegularExpressionMatch match = regex.match(html);
+        if (match.hasMatch()) {
+            QUrl next = m_currentRequest.url.resolved(QUrl(match.captured(1)));
+            if (m_db)
+                m_db->setProductUrl(entry.store, entry.item, next.toString());
+            BrowserRequest req;
+            req.url = next;
+            req.store = entry.store;
+            req.item = entry.item;
+            req.priceRegex = m_currentRequest.priceRegex;
+            req.productRegex = m_currentRequest.productRegex;
+            req.stage = RequestStage::Product;
+            req.searchUrl = m_currentRequest.searchUrl;
+            enqueueBrowserRequest(req);
+            startNextBrowserRequest();
+            return;
+        } else {
+            issue.error = QStringLiteral("Product not found");
+            emit issueOccurred(issue);
+        }
+    }
+
+    startNextBrowserRequest();
+
+    if (--m_pending == 0) {
+        emit progressChanged(m_total - m_pending, m_total);
+        emit fetchFinished();
+    } else {
+        emit progressChanged(m_total - m_pending, m_total);
+    }
 }


### PR DESCRIPTION
## Summary
- improve store search regex and scraping
- fetch product URLs from DB first and use search as fallback
- remove the default `Milk` item and allow empty list
- clean up first run logic
- initialize Qt WebEngine before creating the app and ignore SSL errors

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6841421ef25c8330a9aa63d0a06519e0