### PR TITLE
Improve offline HTML lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ search results match the German product names. If Qt WebEngine is not
 available the application still builds, but any pages that require JavaScript
 will fail to load and an issue is recorded.
 
+If you do not have network access, set the environment variable `OFFLINE_PATH`
+to a directory containing HTML files saved from Firefox. The filenames do not
+need to follow a strict pattern – the application matches files by searching
+for the store and item names inside the page title. A typical `page title •
+Store.html` created by Firefox will work. In this mode the pages are read from
+disk instead of downloaded.
+
 ## Prerequisites
 
 Install the Qt6 development modules required to build the application. On

--- a/fetch_test.cpp
+++ b/fetch_test.cpp
@@ -20,6 +20,9 @@ int main(int argc, char **argv)
     db.open("test.db");
 
     PriceFetcher fetcher(&db);
+    const QByteArray off = qgetenv("OFFLINE_PATH");
+    if (!off.isEmpty())
+        fetcher.setOfflinePath(QString::fromLocal8Bit(off));
     const QStringList args = app.arguments();
     for (int i = 1; i < args.size(); ++i)
         fetcher.addItem(args.at(i));

--- a/src/PriceFetcher.h
+++ b/src/PriceFetcher.h
@@ -36,6 +36,7 @@ class PriceFetcher : public QObject
     Q_OBJECT
 public:
     explicit PriceFetcher(DatabaseManager *db, QObject *parent = nullptr);
+    void setOfflinePath(const QString &path);
     void fetchDailyPrices();
     QStringList storeList() const;
     QStringList categoryList() const;
@@ -70,6 +71,7 @@ private:
     int m_total = 0;
     QNetworkAccessManager m_manager;
     DatabaseManager *m_db = nullptr;
+    QString m_offlinePath;
 
     struct BrowserRequest {
         QUrl url;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,9 @@ int main(int argc, char *argv[])
     PlotWindow w(&db);
 
     PriceFetcher fetcher(&db);
+    const QByteArray off = qgetenv("OFFLINE_PATH");
+    if (!off.isEmpty())
+        fetcher.setOfflinePath(QString::fromLocal8Bit(off));
     w.setStoreList(fetcher.storeList());
     w.setCategoryList(fetcher.categoryList());
     QObject::connect(&fetcher, &PriceFetcher::priceFetched,


### PR DESCRIPTION
## Summary
- match offline HTML files using store and item fragments instead of fixed names
- clarify offline filename requirements in README

## Testing
- `cmake -B build`
- `cmake --build build -j $(nproc)`
- `cmake --install build --prefix dist`


------
https://chatgpt.com/codex/tasks/task_e_68448fa8539883308c800f690f6f86ae