### PR TITLE
Add multilingual settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.qm
+build/
+dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets Network Sql Charts)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Network Sql Charts LinguistTools)
 find_package(Qt6 QUIET COMPONENTS WebEngineCore WebEngineQuick)
 
 if(TARGET Qt6::WebEngineCore AND TARGET Qt6::WebEngineQuick)
@@ -22,6 +22,7 @@ add_executable(Foodcoop
     src/TrendDetector.cpp
     src/PlotWindow.cpp
     src/FirstRunDialog.cpp
+    src/SettingsDialog.cpp
 )
 
 target_link_libraries(Foodcoop PRIVATE
@@ -33,9 +34,17 @@ target_link_libraries(Foodcoop PRIVATE
 if(HAVE_WEBENGINE)
     target_link_libraries(Foodcoop PRIVATE Qt6::WebEngineCore Qt6::WebEngineQuick)
 endif()
-target_compile_definitions(Foodcoop PRIVATE HAVE_WEBENGINE=$<BOOL:${HAVE_WEBENGINE}>)
+target_compile_definitions(Foodcoop PRIVATE HAVE_WEBENGINE=$<BOOL:${HAVE_WEBENGINE}> APP_VERSION="${PROJECT_VERSION}")
 
 install(TARGETS Foodcoop DESTINATION bin)
+
+qt_add_translations(Foodcoop
+    TS_FILES
+        translations/foodcoop_en.ts
+        translations/foodcoop_de.ts
+        translations/foodcoop_fr.ts
+        translations/foodcoop_it.ts
+)
 
 if(HAVE_WEBENGINE)
     add_executable(fetch_test

--- a/src/PlotWindow.cpp
+++ b/src/PlotWindow.cpp
@@ -17,6 +17,10 @@
 #include <QHBoxLayout>
 #include <QDialog>
 #include <QPlainTextEdit>
+#include <QCoreApplication>
+#include <QMenuBar>
+#include <QSettings>
+#include "SettingsDialog.h"
 
 PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     : QMainWindow(parent), m_db(db)
@@ -48,6 +52,7 @@ PlotWindow::PlotWindow(DatabaseManager *db, QWidget *parent)
     m_tabs->addTab(m_table, tr("Table"));
     m_tabs->addTab(issueTab, tr("Issues"));
     setCentralWidget(m_tabs);
+    menuBar()->addAction(tr("Settings"), this, &PlotWindow::openSettings);
 
     // Create user menu dock
     m_menuDock = new QDockWidget(tr("Menu"), this);
@@ -235,4 +240,28 @@ void PlotWindow::showFullLog()
     dialog.setLayout(layout);
     dialog.resize(500, 400);
     dialog.exec();
+}
+
+void PlotWindow::openSettings()
+{
+    QSettings settings;
+    SettingsDialog dlg(QCoreApplication::applicationVersion(), this);
+    dlg.setOfflinePath(settings.value("offlinePath").toString());
+    dlg.setLanguage(settings.value("language", QStringLiteral("en")).toString());
+    if (dlg.exec() == QDialog::Accepted) {
+        settings.setValue("offlinePath", dlg.offlinePath());
+        settings.setValue("language", dlg.language());
+        emit offlinePathChanged(dlg.offlinePath());
+        emit languageChanged(dlg.language());
+    }
+}
+
+void PlotWindow::retranslateUi()
+{
+    m_menuDock->setWindowTitle(tr("Menu"));
+    m_showLogButton->setText(tr("Show Full Log"));
+    m_tabs->setTabText(0, tr("Chart"));
+    m_tabs->setTabText(1, tr("Table"));
+    m_tabs->setTabText(2, tr("Issues"));
+    updateDbInfo();
 }

--- a/src/PlotWindow.h
+++ b/src/PlotWindow.h
@@ -12,6 +12,7 @@
 #include <QTableWidget>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QMenuBar>
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -35,9 +36,13 @@ public slots:
     void onFromDateChanged(const QDate &date);
     void updateIssues();
     void showFullLog();
+    void openSettings();
+    void retranslateUi();
 
 signals:
     void addItemRequested(const QString &item);
+    void offlinePathChanged(const QString &path);
+    void languageChanged(const QString &lang);
 
 private:
     DatabaseManager *m_db;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -1,0 +1,77 @@
+#include "SettingsDialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QComboBox>
+#include <QFileDialog>
+#include <QLabel>
+
+SettingsDialog::SettingsDialog(const QString &version, QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Settings"));
+    QVBoxLayout *layout = new QVBoxLayout(this);
+
+    QHBoxLayout *pathLayout = new QHBoxLayout();
+    m_pathEdit = new QLineEdit(this);
+    m_browseButton = new QPushButton(tr("Select Folder"), this);
+    pathLayout->addWidget(new QLabel(tr("Offline Folder:"), this));
+    pathLayout->addWidget(m_pathEdit);
+    pathLayout->addWidget(m_browseButton);
+    layout->addLayout(pathLayout);
+
+    QHBoxLayout *langLayout = new QHBoxLayout();
+    langLayout->addWidget(new QLabel(tr("Language:"), this));
+    m_languageCombo = new QComboBox(this);
+    m_languageCombo->addItem("English", "en");
+    m_languageCombo->addItem("Deutsch", "de");
+    m_languageCombo->addItem("Français", "fr");
+    m_languageCombo->addItem("Italiano", "it");
+    langLayout->addWidget(m_languageCombo);
+    layout->addLayout(langLayout);
+
+    m_versionLabel = new QLabel(tr("Version: %1").arg(version), this);
+    layout->addWidget(m_versionLabel);
+
+    QHBoxLayout *btnLayout = new QHBoxLayout();
+    QPushButton *ok = new QPushButton(tr("OK"), this);
+    QPushButton *cancel = new QPushButton(tr("Cancel"), this);
+    btnLayout->addStretch();
+    btnLayout->addWidget(ok);
+    btnLayout->addWidget(cancel);
+    layout->addLayout(btnLayout);
+
+    connect(ok, &QPushButton::clicked, this, &QDialog::accept);
+    connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
+    connect(m_browseButton, &QPushButton::clicked, this, &SettingsDialog::browse);
+}
+
+QString SettingsDialog::offlinePath() const
+{
+    return m_pathEdit->text();
+}
+
+QString SettingsDialog::language() const
+{
+    return m_languageCombo->currentData().toString();
+}
+
+void SettingsDialog::setOfflinePath(const QString &path)
+{
+    m_pathEdit->setText(path);
+}
+
+void SettingsDialog::setLanguage(const QString &lang)
+{
+    int idx = m_languageCombo->findData(lang);
+    if (idx >= 0)
+        m_languageCombo->setCurrentIndex(idx);
+}
+
+void SettingsDialog::browse()
+{
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Select Folder"), m_pathEdit->text());
+    if (!dir.isEmpty())
+        m_pathEdit->setText(dir);
+}

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <QDialog>
+class QLineEdit;
+class QComboBox;
+class QPushButton;
+class QLabel;
+
+class SettingsDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit SettingsDialog(const QString &version, QWidget *parent = nullptr);
+    QString offlinePath() const;
+    QString language() const;
+    void setOfflinePath(const QString &path);
+    void setLanguage(const QString &lang);
+private slots:
+    void browse();
+private:
+    QLineEdit *m_pathEdit;
+    QPushButton *m_browseButton;
+    QComboBox *m_languageCombo;
+    QLabel *m_versionLabel;
+};

--- a/translations/foodcoop_de.ts
+++ b/translations/foodcoop_de.ts
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>FirstRunDialog</name>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="8"/>
+        <source>Initial Scrape</source>
+        <translation>Erstes Einlesen</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="10"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="11"/>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Show Log</source>
+        <translation>Log anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Hide Log</source>
+        <translation>Log verbergen</translation>
+    </message>
+</context>
+<context>
+    <name>PlotWindow</name>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <source>Price</source>
+        <translation>Preis</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Store</source>
+        <translation>Geschäft</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Item</source>
+        <translation>Artikel</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="44"/>
+        <location filename="../src/PlotWindow.cpp" line="262"/>
+        <source>Show Full Log</source>
+        <translation>Vollen Log anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="51"/>
+        <location filename="../src/PlotWindow.cpp" line="263"/>
+        <source>Chart</source>
+        <translation>Diagramm</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="52"/>
+        <location filename="../src/PlotWindow.cpp" line="264"/>
+        <source>Table</source>
+        <translation>Tabelle</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="53"/>
+        <location filename="../src/PlotWindow.cpp" line="265"/>
+        <source>Issues</source>
+        <translation>Probleme</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="55"/>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="58"/>
+        <location filename="../src/PlotWindow.cpp" line="261"/>
+        <source>Menu</source>
+        <translation>Menü</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="65"/>
+        <location filename="../src/PlotWindow.cpp" line="162"/>
+        <source>Browser: Idle</source>
+        <translation>Browser: Leerlauf</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="68"/>
+        <source>Market:</source>
+        <translation>Markt:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="74"/>
+        <source>Category:</source>
+        <translation>Kategorie:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="81"/>
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="90"/>
+        <source>From:</source>
+        <translation>Von:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="125"/>
+        <source>Price trend: %1</source>
+        <translation>Preistrend: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="135"/>
+        <location filename="../src/PlotWindow.cpp" line="200"/>
+        <source>Current price: %1 %2 (%3)</source>
+        <translation>Aktueller Preis: %1 %2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="140"/>
+        <location filename="../src/PlotWindow.cpp" line="205"/>
+        <source>Current price: N/A</source>
+        <translation>Aktueller Preis: n/v</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="157"/>
+        <source>Browser: Fetching</source>
+        <translation>Browser: Laden</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="197"/>
+        <source>Database size: %1 KB</source>
+        <translation>Datenbankgröße: %1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="228"/>
+        <source>Full Issue Log</source>
+        <translation>Vollständiges Fehlerprotokoll</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/main.cpp" line="41"/>
+        <source>No Data</source>
+        <translation>Keine Daten</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="42"/>
+        <source>None of the stores returned any data. The application cannot continue.</source>
+        <translation>Keiner der Läden lieferte Daten. Die Anwendung kann nicht fortfahren.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="13"/>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="18"/>
+        <location filename="../src/SettingsDialog.cpp" line="74"/>
+        <source>Select Folder</source>
+        <translation>Ordner wählen</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="19"/>
+        <source>Offline Folder:</source>
+        <translation>Offline-Ordner:</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="25"/>
+        <source>Language:</source>
+        <translation>Sprache:</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="34"/>
+        <source>Version: %1</source>
+        <translation>Version: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="38"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="39"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+</context>
+</TS>

--- a/translations/foodcoop_en.ts
+++ b/translations/foodcoop_en.ts
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>FirstRunDialog</name>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="8"/>
+        <source>Initial Scrape</source>
+        <translation>Initial Scrape</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="10"/>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="11"/>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Show Log</source>
+        <translation>Show Log</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Hide Log</source>
+        <translation>Hide Log</translation>
+    </message>
+</context>
+<context>
+    <name>PlotWindow</name>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Date</source>
+        <translation>Date</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <source>Price</source>
+        <translation>Price</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Store</source>
+        <translation>Store</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Item</source>
+        <translation>Item</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="44"/>
+        <location filename="../src/PlotWindow.cpp" line="262"/>
+        <source>Show Full Log</source>
+        <translation>Show Full Log</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="51"/>
+        <location filename="../src/PlotWindow.cpp" line="263"/>
+        <source>Chart</source>
+        <translation>Chart</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="52"/>
+        <location filename="../src/PlotWindow.cpp" line="264"/>
+        <source>Table</source>
+        <translation>Table</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="53"/>
+        <location filename="../src/PlotWindow.cpp" line="265"/>
+        <source>Issues</source>
+        <translation>Issues</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="55"/>
+        <source>Settings</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="58"/>
+        <location filename="../src/PlotWindow.cpp" line="261"/>
+        <source>Menu</source>
+        <translation>Menu</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="65"/>
+        <location filename="../src/PlotWindow.cpp" line="162"/>
+        <source>Browser: Idle</source>
+        <translation>Browser: Idle</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="68"/>
+        <source>Market:</source>
+        <translation>Market:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="74"/>
+        <source>Category:</source>
+        <translation>Category:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="81"/>
+        <source>Add</source>
+        <translation>Add</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="90"/>
+        <source>From:</source>
+        <translation>From:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="125"/>
+        <source>Price trend: %1</source>
+        <translation>Price trend: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="135"/>
+        <location filename="../src/PlotWindow.cpp" line="200"/>
+        <source>Current price: %1 %2 (%3)</source>
+        <translation>Current price: %1 %2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="140"/>
+        <location filename="../src/PlotWindow.cpp" line="205"/>
+        <source>Current price: N/A</source>
+        <translation>Current price: N/A</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="157"/>
+        <source>Browser: Fetching</source>
+        <translation>Browser: Fetching</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="197"/>
+        <source>Database size: %1 KB</source>
+        <translation>Database size: %1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="228"/>
+        <source>Full Issue Log</source>
+        <translation>Full Issue Log</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/main.cpp" line="41"/>
+        <source>No Data</source>
+        <translation>No Data</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="42"/>
+        <source>None of the stores returned any data. The application cannot continue.</source>
+        <translation>None of the stores returned any data. The application cannot continue.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="13"/>
+        <source>Settings</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="18"/>
+        <location filename="../src/SettingsDialog.cpp" line="74"/>
+        <source>Select Folder</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="19"/>
+        <source>Offline Folder:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="25"/>
+        <source>Language:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="34"/>
+        <source>Version: %1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="38"/>
+        <source>OK</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="39"/>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
+    </message>
+</context>
+</TS>

--- a/translations/foodcoop_fr.ts
+++ b/translations/foodcoop_fr.ts
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>FirstRunDialog</name>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="8"/>
+        <source>Initial Scrape</source>
+        <translation>Récupération initiale</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="10"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="11"/>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Show Log</source>
+        <translation>Afficher le journal</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Hide Log</source>
+        <translation>Masquer le journal</translation>
+    </message>
+</context>
+<context>
+    <name>PlotWindow</name>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Date</source>
+        <translation>Date</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <source>Price</source>
+        <translation>Prix</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Store</source>
+        <translation>Magasin</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Item</source>
+        <translation>Produit</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="44"/>
+        <location filename="../src/PlotWindow.cpp" line="262"/>
+        <source>Show Full Log</source>
+        <translation>Afficher le journal complet</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="51"/>
+        <location filename="../src/PlotWindow.cpp" line="263"/>
+        <source>Chart</source>
+        <translation>Graphique</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="52"/>
+        <location filename="../src/PlotWindow.cpp" line="264"/>
+        <source>Table</source>
+        <translation>Tableau</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="53"/>
+        <location filename="../src/PlotWindow.cpp" line="265"/>
+        <source>Issues</source>
+        <translation>Problèmes</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="55"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="58"/>
+        <location filename="../src/PlotWindow.cpp" line="261"/>
+        <source>Menu</source>
+        <translation>Menu</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="65"/>
+        <location filename="../src/PlotWindow.cpp" line="162"/>
+        <source>Browser: Idle</source>
+        <translation>Navigateur : inactif</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="68"/>
+        <source>Market:</source>
+        <translation>Marché :</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="74"/>
+        <source>Category:</source>
+        <translation>Catégorie :</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="81"/>
+        <source>Add</source>
+        <translation>Ajouter</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="90"/>
+        <source>From:</source>
+        <translation>Depuis :</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="125"/>
+        <source>Price trend: %1</source>
+        <translation>Tendance des prix : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="135"/>
+        <location filename="../src/PlotWindow.cpp" line="200"/>
+        <source>Current price: %1 %2 (%3)</source>
+        <translation>Prix actuel : %1 %2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="140"/>
+        <location filename="../src/PlotWindow.cpp" line="205"/>
+        <source>Current price: N/A</source>
+        <translation>Prix actuel : N/A</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="157"/>
+        <source>Browser: Fetching</source>
+        <translation>Navigateur : récupération</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="197"/>
+        <source>Database size: %1 KB</source>
+        <translation>Taille de la base : %1 Ko</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="228"/>
+        <source>Full Issue Log</source>
+        <translation>Journal complet des problèmes</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/main.cpp" line="41"/>
+        <source>No Data</source>
+        <translation>Pas de données</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="42"/>
+        <source>None of the stores returned any data. The application cannot continue.</source>
+        <translation>Aucun magasin n'a retourné de données. L'application ne peut pas continuer.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="13"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="18"/>
+        <location filename="../src/SettingsDialog.cpp" line="74"/>
+        <source>Select Folder</source>
+        <translation>Sélectionner le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="19"/>
+        <source>Offline Folder:</source>
+        <translation>Dossier hors ligne :</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="25"/>
+        <source>Language:</source>
+        <translation>Langue :</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="34"/>
+        <source>Version: %1</source>
+        <translation>Version : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="38"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="39"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+</TS>

--- a/translations/foodcoop_it.ts
+++ b/translations/foodcoop_it.ts
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it_IT">
+<context>
+    <name>FirstRunDialog</name>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="8"/>
+        <source>Initial Scrape</source>
+        <translation>Primo recupero</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="10"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="11"/>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Show Log</source>
+        <translation>Mostra log</translation>
+    </message>
+    <message>
+        <location filename="../src/FirstRunDialog.cpp" line="34"/>
+        <source>Hide Log</source>
+        <translation>Nascondi log</translation>
+    </message>
+</context>
+<context>
+    <name>PlotWindow</name>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="35"/>
+        <source>Price</source>
+        <translation>Prezzo</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Store</source>
+        <translation>Negozio</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Item</source>
+        <translation>Articolo</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="39"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="44"/>
+        <location filename="../src/PlotWindow.cpp" line="262"/>
+        <source>Show Full Log</source>
+        <translation>Mostra log completo</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="51"/>
+        <location filename="../src/PlotWindow.cpp" line="263"/>
+        <source>Chart</source>
+        <translation>Grafico</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="52"/>
+        <location filename="../src/PlotWindow.cpp" line="264"/>
+        <source>Table</source>
+        <translation>Tabella</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="53"/>
+        <location filename="../src/PlotWindow.cpp" line="265"/>
+        <source>Issues</source>
+        <translation>Problemi</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="55"/>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="58"/>
+        <location filename="../src/PlotWindow.cpp" line="261"/>
+        <source>Menu</source>
+        <translation>Menu</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="65"/>
+        <location filename="../src/PlotWindow.cpp" line="162"/>
+        <source>Browser: Idle</source>
+        <translation>Browser: inattivo</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="68"/>
+        <source>Market:</source>
+        <translation>Mercato:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="74"/>
+        <source>Category:</source>
+        <translation>Categoria:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="81"/>
+        <source>Add</source>
+        <translation>Aggiungi</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="90"/>
+        <source>From:</source>
+        <translation>Da:</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="125"/>
+        <source>Price trend: %1</source>
+        <translation>Tendenza prezzo: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="135"/>
+        <location filename="../src/PlotWindow.cpp" line="200"/>
+        <source>Current price: %1 %2 (%3)</source>
+        <translation>Prezzo attuale: %1 %2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="140"/>
+        <location filename="../src/PlotWindow.cpp" line="205"/>
+        <source>Current price: N/A</source>
+        <translation>Prezzo attuale: N/D</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="157"/>
+        <source>Browser: Fetching</source>
+        <translation>Browser: ricerca</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="197"/>
+        <source>Database size: %1 KB</source>
+        <translation>Dimensione database: %1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/PlotWindow.cpp" line="228"/>
+        <source>Full Issue Log</source>
+        <translation>Log completo dei problemi</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/main.cpp" line="41"/>
+        <source>No Data</source>
+        <translation>Nessun dato</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="42"/>
+        <source>None of the stores returned any data. The application cannot continue.</source>
+        <translation>Nessun negozio ha restituito dati. L'applicazione non può continuare.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="13"/>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="18"/>
+        <location filename="../src/SettingsDialog.cpp" line="74"/>
+        <source>Select Folder</source>
+        <translation>Seleziona cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="19"/>
+        <source>Offline Folder:</source>
+        <translation>Cartella offline:</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="25"/>
+        <source>Language:</source>
+        <translation>Lingua:</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="34"/>
+        <source>Version: %1</source>
+        <translation>Versione: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="38"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsDialog.cpp" line="39"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary
- provide translation files for English, German, French and Italian
- add Settings dialog for language and offline folder
- compile translations from `.ts` files during the build
- ignore generated `.qm` files in git

## Testing
- `cmake -B build`
- `cmake --build build -j $(nproc)`
- `cmake --install build --prefix dist`


------
https://chatgpt.com/codex/tasks/task_e_68449529f8f48330af86cc4411720340